### PR TITLE
Update netsyn version to the correct version

### DIFF
--- a/netsyn/__init__.py
+++ b/netsyn/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'


### PR DESCRIPTION
Netsyn version has not been updated when we release netsyn v0.1.2.  
This PR simply updates version to .v0.1.2 